### PR TITLE
fix(desktop): drop invalid app.title field in tauri.conf.json

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicovrc/tauri/dev/crates/tauri-config-schema/schema.json",
+  "$schema": "https://schema.tauri.app/config/2",
   "productName": "Archon Desktop",
   "version": "0.1.0",
   "identifier": "com.archon.desktop",
@@ -10,7 +10,6 @@
     "beforeBuildCommand": "cd .. && bun run build"
   },
   "app": {
-    "title": "Archon Desktop",
     "windows": [
       {
         "title": "Archon Desktop",


### PR DESCRIPTION
## Summary
- Tauri v2 rejects `app.title` — title lives on each `app.windows[N]` entry. Ralph's scaffold had both; removed the invalid duplicate.
- Bonus: swapped dead `$schema` URL (personal fork) for the official one at `schema.tauri.app/config/2`.

## Why
`bun tauri dev` and `bun tauri build` both fail with `Additional properties are not allowed ('title' was unexpected)` until this is removed. Caught on first run on Windows.

## Test plan
- [x] Verified the duplicate `title` (window spec already sets it)
- [ ] Re-run `bun tauri dev` / `bun tauri build` on Windows — should get past the schema check