### PR TITLE
fix(desktop): scope tauri beforeDev/beforeBuild to the desktop package

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "cd .. && bun run dev",
-    "beforeBuildCommand": "cd .. && bun run build"
+    "beforeDevCommand": "bun run dev",
+    "beforeBuildCommand": "bun run build"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- `cd .. && bun run dev` from \`packages/desktop/\` climbed to the monorepo root and fired the whole-workspace dev script. That spawned @archon/server (which crashes fatal on Windows without AI creds in .env) plus docs-web + web.
- Replaced with `bun run dev` / `bun run build` so tauri only touches the desktop package's local vite.

## Test plan
- [ ] `bun tauri dev` on Windows launches the window without @archon/server spinning up.